### PR TITLE
Add getTickets controller, update joint table on ticket reservation, limit users to create upto 5 tickets per event

### DIFF
--- a/server/controllers/ticketController.js
+++ b/server/controllers/ticketController.js
@@ -41,27 +41,70 @@ const createTicket = (req, res, next) => {
   const ticket_price = req.body.ticket_price;
   const ticket_serial = crypto.randomUUID({ disableEntropyCache: true });
 
-  // create a new ticket
-  Ticket.create({
-    user_id: user_id,
-    event_id: event_id,
-    seats_reserved: seats_reserved,
-    ticket_type: ticket_type,
-    ticket_price: ticket_price,
-    ticket_serial: ticket_serial,
+  let remaining_reservations;
+  // check how many tickets the user has reserved so far for the specified event
+
+  Ticket.findAll({
+    where: {
+      event_id: event_id,
+      user_id: user_id,
+    },
   })
-    .then((result) => {
-      // upon successful ticket reservation, update joint table
-      UserEvent.create({
-        user_id: user_id,
-        event_id: event_id,
-      }).then((userEvent) => {
-        res.status(200).json({
-          status: "success",
-          message: "Ticket created successfully",
-          data: result,
+    .then((data) => {
+      // Calculate the total seats reserved
+
+      const totalSeatsReserved = data.reduce((total, reservation) => {
+        return total + reservation.seats_reserved;
+      }, 0);
+
+      remaining_reservations = 5 - totalSeatsReserved;
+
+      if (remaining_reservations === 0 || remaining_reservations < 0) {
+        res.status(403).json({
+          status: "failed",
+          message: "Ticket reservation limit per event exceeded",
+          data: [],
         });
-      });
+      } else {
+        if (remaining_reservations >= seats_reserved) {
+          // create a new ticket
+          Ticket.create({
+            user_id: user_id,
+            event_id: event_id,
+            seats_reserved: seats_reserved,
+            ticket_type: ticket_type,
+            ticket_price: ticket_price,
+            ticket_serial: ticket_serial,
+          })
+            .then((result) => {
+              // upon successful ticket reservation, update joint table
+              UserEvent.create({
+                user_id: user_id,
+                event_id: event_id,
+              }).then((userEvent) => {
+                res.status(200).json({
+                  status: "success",
+                  message: "Ticket created successfully",
+                  data: result,
+                });
+              });
+            })
+            .catch((error) => {
+              if (!error.statusCode) {
+                error.statusCode = 422;
+              }
+              error.message = "Ticket reservation failed";
+              next(error);
+            });
+        } else {
+          // if user wants to reserve more than remaining reservation
+          res.status(403).json({
+            status: "failed",
+            message: `You can only reserve ${remaining_reservations} seats for this event.`,
+            data: result,
+          });
+        }
+      }
     })
     .catch((error) => {
       if (!error.statusCode) {


### PR DESCRIPTION
This PR does the following:
- fixes #6 
- defines `getTickets` controller to read all tickets created by current user
- update join `UserEvents` table with data when a ticket is reserved for M:M relationship